### PR TITLE
Fix yield_now

### DIFF
--- a/photonio-uring/src/task/mod.rs
+++ b/photonio-uring/src/task/mod.rs
@@ -34,7 +34,7 @@ impl Task {
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
-        S: Schedule + Send,
+        S: Schedule + Send + Sync,
     {
         let suit = Arc::new(Suit::new(id, future, schedule));
         let task = Self::from_suit(suit.clone());
@@ -46,7 +46,7 @@ impl Task {
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
-        S: Schedule + Send,
+        S: Schedule + Send + Sync,
     {
         let head = unsafe { Arc::from_raw(Arc::into_raw(suit) as *const Head) };
         Self(ManuallyDrop::new(head))

--- a/photonio/tests/yield_now.rs
+++ b/photonio/tests/yield_now.rs
@@ -1,0 +1,6 @@
+use photonio::task;
+
+#[photonio::test]
+async fn yield_now() {
+    task::yield_now().await;
+}


### PR DESCRIPTION
The original implementation will cause a deadlock in `yield_now()`. It turns out the scheduler doesn't need to protect by a mutex.